### PR TITLE
Fix addEventListener handler

### DIFF
--- a/src/SecureStorage.js
+++ b/src/SecureStorage.js
@@ -47,7 +47,7 @@ if (!global.openSecureStorage)
 		});	
 	};
 	
-	var delayedExpirationCheck = function() {
+	function delayedExpirationCheck() {
 		setTimeout(checkExpired, 10000);
 	}
 	

--- a/src/SecureStorage.js
+++ b/src/SecureStorage.js
@@ -46,10 +46,13 @@ if (!global.openSecureStorage)
 			removeStore(storeName);
 		});	
 	};
-
-
+	
+	var delayedExpirationCheck = function() {
+		setTimeout(checkExpired, 10000);
+	}
+	
 	// Setup expired checker
-	global.addEventListener('load', setTimeout(checkExpired, 10000), false);
+	global.addEventListener('load', delayedExpirationCheck, false);
 }
 
 

--- a/src/SecureStorage.js
+++ b/src/SecureStorage.js
@@ -47,9 +47,9 @@ if (!global.openSecureStorage)
 		});	
 	};
 	
-	function delayedExpirationCheck() {
+	var delayedExpirationCheck = function() {
 		setTimeout(checkExpired, 10000);
-	}
+	};
 	
 	// Setup expired checker
 	global.addEventListener('load', delayedExpirationCheck, false);


### PR DESCRIPTION
Using `setTimeout` as an handler in `addEventListener` doesn't work anymore in Safari 10.3.1 and produce a `TypeError`.